### PR TITLE
Change zookeeper version to "*"

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "dependencies": {
     "ejs": ">= 0.7.2",
     "express": "3.x",
-    "zookeeper":">=3.4.1-4",
+    "zookeeper":"*",
     "express-namespace":">=0.1.1"
   }
 }


### PR DESCRIPTION
Some of node-zookeeper stable releases has prerelease tag in version number. After recent changes in node-semver, prerelease versions match to given range only when one of given comparators has the same major, minor, and patch number. So comparator `>=3.4.1-4` matches only to prereleases of `3.4.1` version. For now, the latest matching version is 3.4.3, unfortunately it can't be installed because dead link to zookeeper sources.

Changing range from `>=3.4.1-4` to `*` solves problem. In theory `* >=3.4.1-4` should also work, but it's not.
